### PR TITLE
*added nuget-restore

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,8 @@ skip_tags: true
 skip_branch_with_pr: true
 image: Visual Studio 2019
 configuration: Release
+before_build:
+- nuget restore TargetFrameworkMigrator.sln
 build:
   project: TargetFrameworkMigrator.sln
   parallel: true


### PR DESCRIPTION
This PR is a response to https://github.com/TargetFrameworkMigrator/TargetFrameworkMigrator/pull/102

I noticed that the logfile of the failing PR-build indicates that multiple namespaces can not be validated because assemblies might be missing. I opened the solution and noticed that all these namespaces are from nuget-packages. These packages are restored automatically by the visual studio client but not in the build process.

In this PR i try to update the appveyor.yml to include the missing step that is required to restore the nuget packages in the build process